### PR TITLE
Package.swift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
 *.podspec linguist-vendored
+Podfile linguist-vendored

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.podspec linguist-vendored

--- a/Ease.podspec
+++ b/Ease.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 s.name         = 'Ease'
-s.version      = '3.1.0'
+s.version      = '3.1.1'
 s.ios.deployment_target = '9.0'
 s.summary      = 'Its magic'
 s.description  = <<-DESC

--- a/Ease/Classes/Ease.swift
+++ b/Ease/Classes/Ease.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 public extension Notification.Name {
     static let easeStarted = Notification.Name("EaseStarted")

--- a/Package.swift
+++ b/Package.swift
@@ -1,3 +1,4 @@
+// swift-tools-version:5.0
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let package = Package(
     name: "Ease",
+    platforms: [.iOS(.v9)],
     products: [
         .library(name: "Ease", targets: ["Ease"])
     ],

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,11 @@
+import PackageDescription
+
+let package = Package(
+    name: "Ease",
+    products: [
+        .library(name: "Ease", targets: ["Ease"])
+    ],
+    targets: [
+        .target(name: "Ease", path: "Ease/Classes")
+    ]
+)


### PR DESCRIPTION
Adding a Package.swift allows anyone to add Ease as a SPM dependency through Xcode 11 or manually.

`*.podspec linguist-vendored` gets the project to display "Swift 100%" in Github.